### PR TITLE
chore: manually close release on sonatype

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -99,6 +99,11 @@ pipeline {
                         }
                     }
                 }
+                stage('Manually close and release on sonatype [ x.x ]') {
+                    steps {
+                        input(message='Log on to https://oss.sonatype.org/ and manually close and release to maven central.')
+                    }
+                }
             }
         }
         stage('Steps [ feature ]') {

--- a/pom.xml
+++ b/pom.xml
@@ -84,7 +84,8 @@
           <configuration>
             <serverId>${sonatype.id}</serverId>
             <nexusUrl>https://oss.sonatype.org/</nexusUrl>
-            <autoReleaseAfterClose>true</autoReleaseAfterClose>
+            <!-- closing the repo in the build fails miserably with a connection reset error -->
+            <skipStagingRepositoryClose>true</skipStagingRepositoryClose>
           </configuration>
         </plugin>
         <plugin>


### PR DESCRIPTION
The auto close on sonatype fails with a connection reset error.
Removes the maven plugin configuration that closes the repository and releases it.
Adds a manual step to the Jenkinsfile.